### PR TITLE
Refactor token command inputs to use `token-id` instead of `token`

### DIFF
--- a/src/docs/features.md
+++ b/src/docs/features.md
@@ -3,7 +3,7 @@
 The bot supports the following slash commands:
 
 - **`/ping`**: A simple test command. The bot replies with "Pong!". This is useful for checking if the bot is online and responsive.
-- **`/price`**: Takes 1 input `token`, Fetches and displays the current price of that given token.
-- **`/mcap`**: Takes 1 input `token`,  Retrieves and displays the current market capitalization of that token.
-- **`/price-change`**: Takes 1 input `token`, Shows the percentage change in that token's price over the last 24 hours, along with an emoji (📈 or 📉) indicating the direction of change.
-- **`/volume`**: Takes 1 input `token`, Returns the 24-hour trading volume of that token.
+- **`/price`**: Takes 1 input `token-id`, Fetches and displays the current price of that given token.
+- **`/mcap`**: Takes 1 input `token-id`,  Retrieves and displays the current market capitalization of that token.
+- **`/price-change`**: Takes 1 input `token-id`, Shows the percentage change in that token's price over the last 24 hours, along with an emoji (📈 or 📉) indicating the direction of change.
+- **`/volume`**: Takes 1 input `token-id`, Returns the 24-hour trading volume of that token.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,0 @@
-export const UNISWAP_LINK = "https://app.uniswap.org/explore/tokens/base/0x047157cffb8841a64db93fd4e29fa3796b78466c";


### PR DESCRIPTION
- Resolves : #9 

* Updated command definitions and interaction handling to replace 'fixed options' `token` with 'string option' `token-id` for better clarity.
* All commands can now work with any token from coingecko
* Removed unused `UNISWAP_LINK` constant.
* Updated documentation to reflect changes in command parameters.

**All price related data is now coming from coingecko**