### PR TITLE
Added `/delete-alert` command 

### DIFF
--- a/src/alertCommands/deletePriceAlert.ts
+++ b/src/alertCommands/deletePriceAlert.ts
@@ -1,0 +1,110 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  PermissionFlagsBits,
+} from "discord.js";
+import logger from "../utils/logger";
+import prisma from "../utils/prisma";
+
+export const deletePriceAlertCommand = new SlashCommandBuilder()
+  .setName("delete-alert")
+  .setDescription("Deletes a price alert by its ID.")
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
+  .addStringOption((option) =>
+    option
+      .setName("id")
+      .setDescription("The ID of the alert to delete.")
+      .setRequired(true)
+  )
+  .toJSON();
+
+export async function handleDeletePriceAlert(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  const alertId = interaction.options.getString("id", true);
+  const { guildId, channelId } = interaction;
+
+  if (!guildId || !channelId) {
+    await interaction.reply({
+      content: "This command can only be used in a server channel.",
+      flags: 64,
+    });
+    return;
+  }
+
+  try {
+    logger.info(`Attempting to delete alert ${alertId} from guild ${guildId} channel ${channelId}`);
+
+    // First check if the alert exists and belongs to this server/channel
+    const alert = await prisma.alert.findUnique({
+      where: {
+        id: alertId,
+        discordServerId: guildId,
+        channelId: channelId,
+      },
+      include: {
+        priceAlert: true
+      }
+    }).catch(err => {
+      logger.error('Error finding alert:', err);
+      throw err;
+    });
+
+    if (!alert) {
+      logger.info(`Alert ${alertId} not found or not accessible`);
+      await interaction.reply({
+        content: "Alert not found or you do not have permission to delete it.",
+        flags: 64,
+      });
+      return;
+    }
+
+    logger.info(`Found alert ${alertId}, has priceAlert: ${!!alert.priceAlert}`);
+
+    try {
+      // Delete the PriceAlert first if it exists
+      if (alert.priceAlert) {
+        logger.info(`Deleting PriceAlert for alert ${alertId}`);
+        await prisma.priceAlert.delete({
+          where: {
+            alertId: alertId
+          }
+        });
+      }
+
+      // Then delete the Alert
+      logger.info(`Deleting Alert ${alertId}`);
+      await prisma.alert.delete({
+        where: {
+          id: alertId
+        }
+      });
+
+      logger.info(`Successfully deleted alert ${alertId}`);
+      await interaction.reply({
+        content: `Successfully deleted alert with ID: \`${alertId}\``,
+        flags: 64,
+      });
+    } catch (deleteError) {
+      logger.error('Error during delete operation:', deleteError);
+      throw deleteError;
+    }
+  } catch (error) {
+    logger.error("Error deleting price alert:", {
+      error,
+      alertId,
+      guildId,
+      channelId
+    });
+    
+    let errorMessage = "Sorry, there was an error deleting the price alert.";
+    if (error instanceof Error) {
+      errorMessage += ` Error: ${error.message}`;
+    }
+    
+    await interaction.reply({
+      content: errorMessage,
+      flags: 64,
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,10 @@ import {
   editPriceAlertCommand,
   handleEditPriceAlert,
 } from "./alertCommands/editPriceAlert";
+import {
+  deletePriceAlertCommand,
+  handleDeletePriceAlert,
+} from "./alertCommands/deletePriceAlert";
 
 import { getDevPrice } from "./utils/uniswapPrice";
 
@@ -110,6 +114,7 @@ const commandsData: ApplicationCommandDataResolvable[] = [
   createPriceAlertCommand,
   listPriceAlertsCommand,
   editPriceAlertCommand,
+  deletePriceAlertCommand,
 ];
 
 async function createDiscordServer(): Promise<Client> {
@@ -226,6 +231,8 @@ async function handleInteractionCommands(
     await handleListPriceAlerts(interaction);
   } else if (commandName === "edit-price-alert") {
     await handleEditPriceAlert(interaction);
+  } else if (commandName === "delete-alert") {
+    await handleDeletePriceAlert(interaction);
   }
 }
 


### PR DESCRIPTION
This PR :
- Resolves : #13 

New:
* Introduced a new command `delete-alert` to allow users to delete price alerts by ID.
* Implemented the `handleDeletePriceAlert` function to manage the deletion process, including validation and error handling.
* Updated the command registration in the main application to include the new delete command.