### PR TITLE
Fix : wrong field query in`/create-price-alert` command

### DIFF
--- a/src/alertCommands/createPriceAlert.ts
+++ b/src/alertCommands/createPriceAlert.ts
@@ -23,7 +23,7 @@ export const createPriceAlertCommand = new SlashCommandBuilder()
       .setDescription("The token to create an alert for (supported: dev, eth, btc)")
       .setRequired(true)
       .addChoices(
-        { name: 'DEV', value: 'scout-protocol-token' },
+        { name: 'scout-protocol-token (DEV)', value: 'scout-protocol-token' },
         { name: 'Bitcoin (BTC)', value: 'bitcoin' },
         { name: 'Ethereum (ETH)', value: 'ethereum' }
       ))

--- a/src/utils/databasePrice.ts
+++ b/src/utils/databasePrice.ts
@@ -62,7 +62,7 @@ export async function getLatestTokenPriceWithMetadata(tokenId: string): Promise<
     const latestPrice = await prisma.tokenPrice.findFirst({
       where: {
         token: {
-            id: standardizedId // Use 'id' or the correct field for token ID
+          address: standardizedId 
         }
       },
       orderBy: {
@@ -90,7 +90,7 @@ async function getLatestTokenPriceRecord(standardizedId: string): Promise<{ pric
         const record = await prisma.tokenPrice.findFirst({
             where: {
                 token: {
-                    id: standardizedId // Use 'id' or the correct field for token ID
+                    address: standardizedId // Use 'id' or the correct field for token ID
                 }
             },
             orderBy: {


### PR DESCRIPTION


* Modified the createPriceAlert command to clarify the DEV token identifier in the user interface.
* Updated database queries to use 'address' instead of 'id' for token identification, ensuring consistency across the application.