### PR TITLE
feat: add bulk enable/disable options to price alert commands

### DIFF
--- a/src/alertCommands/deletePriceAlert.ts
+++ b/src/alertCommands/deletePriceAlert.ts
@@ -39,7 +39,7 @@ export async function handleDeletePriceAlert(
     return;
   }
 
-  // Check if at least one option is provided
+  
   if (!alertId && deleteDisabled === null) {
     await interaction.reply({
       content: "Please provide either an alert ID or use the delete-disabled option.",
@@ -48,13 +48,13 @@ export async function handleDeletePriceAlert(
     return;
   }
 
-  // Handle deleting all disabled alerts
+  // bulk
   if (deleteDisabled === true) {
     await handleDeleteDisabledAlerts(interaction, guildId, channelId);
     return;
   }
 
-  // Handle deleting a specific alert by ID
+  // specific
   if (alertId) {
     await handleDeleteSpecificAlert(interaction, alertId, guildId, channelId);
     return;
@@ -69,7 +69,7 @@ async function handleDeleteDisabledAlerts(
   try {
     logger.info(`Attempting to delete all disabled alerts from guild ${guildId} channel ${channelId}`);
 
-    // Find all disabled alerts in this channel
+    
     const disabledAlerts = await prisma.alert.findMany({
       where: {
         discordServerId: guildId,
@@ -94,11 +94,11 @@ async function handleDeleteDisabledAlerts(
 
     logger.info(`Found ${disabledAlerts.length} disabled alerts to delete`);
 
-    // Delete all disabled alerts
+    
     let deletedCount = 0;
     for (const alert of disabledAlerts) {
       try {
-        // Delete the PriceAlert first if it exists
+        
         if (alert.priceAlert) {
           await prisma.priceAlert.delete({
             where: {
@@ -107,7 +107,7 @@ async function handleDeleteDisabledAlerts(
           });
         }
 
-        // Then delete the Alert
+        
         await prisma.alert.delete({
           where: {
             id: alert.id,
@@ -117,7 +117,7 @@ async function handleDeleteDisabledAlerts(
         deletedCount++;
       } catch (deleteError) {
         logger.error(`Error deleting disabled alert ${alert.id}:`, deleteError);
-        // Continue with other alerts even if one fails
+        
       }
     }
 
@@ -154,7 +154,7 @@ async function handleDeleteSpecificAlert(
   try {
     logger.info(`Attempting to delete alert ${alertId} from guild ${guildId} channel ${channelId}`);
 
-    // First check if the alert exists and belongs to this server/channel
+    // alert ownership check
     const alert = await prisma.alert.findUnique({
       where: {
         id: alertId,
@@ -181,7 +181,7 @@ async function handleDeleteSpecificAlert(
     logger.info(`Found alert ${alertId}, has priceAlert: ${!!alert.priceAlert}`);
 
     try {
-      // Delete the PriceAlert first if it exists
+      
       if (alert.priceAlert) {
         logger.info(`Deleting PriceAlert for alert ${alertId}`);
         await prisma.priceAlert.delete({
@@ -191,7 +191,7 @@ async function handleDeleteSpecificAlert(
         });
       }
 
-      // Then delete the Alert
+      
       logger.info(`Deleting Alert ${alertId}`);
       await prisma.alert.delete({
         where: {

--- a/src/alertCommands/deletePriceAlert.ts
+++ b/src/alertCommands/deletePriceAlert.ts
@@ -8,20 +8,27 @@ import prisma from "../utils/prisma";
 
 export const deletePriceAlertCommand = new SlashCommandBuilder()
   .setName("delete-alert")
-  .setDescription("Deletes a price alert by its ID.")
+  .setDescription("Deletes a price alert by its ID or all disabled alerts.")
   .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
   .addStringOption((option) =>
     option
       .setName("id")
       .setDescription("The ID of the alert to delete.")
-      .setRequired(true)
+      .setRequired(false)
+  )
+  .addBooleanOption((option) =>
+    option
+      .setName("delete-disabled")
+      .setDescription("Delete all disabled alerts in this channel.")
+      .setRequired(false)
   )
   .toJSON();
 
 export async function handleDeletePriceAlert(
   interaction: ChatInputCommandInteraction
 ): Promise<void> {
-  const alertId = interaction.options.getString("id", true);
+  const alertId = interaction.options.getString("id");
+  const deleteDisabled = interaction.options.getBoolean("delete-disabled");
   const { guildId, channelId } = interaction;
 
   if (!guildId || !channelId) {
@@ -32,6 +39,118 @@ export async function handleDeletePriceAlert(
     return;
   }
 
+  // Check if at least one option is provided
+  if (!alertId && deleteDisabled === null) {
+    await interaction.reply({
+      content: "Please provide either an alert ID or use the delete-disabled option.",
+      flags: 64,
+    });
+    return;
+  }
+
+  // Handle deleting all disabled alerts
+  if (deleteDisabled === true) {
+    await handleDeleteDisabledAlerts(interaction, guildId, channelId);
+    return;
+  }
+
+  // Handle deleting a specific alert by ID
+  if (alertId) {
+    await handleDeleteSpecificAlert(interaction, alertId, guildId, channelId);
+    return;
+  }
+}
+
+async function handleDeleteDisabledAlerts(
+  interaction: ChatInputCommandInteraction,
+  guildId: string,
+  channelId: string
+): Promise<void> {
+  try {
+    logger.info(`Attempting to delete all disabled alerts from guild ${guildId} channel ${channelId}`);
+
+    // Find all disabled alerts in this channel
+    const disabledAlerts = await prisma.alert.findMany({
+      where: {
+        discordServerId: guildId,
+        channelId: channelId,
+        enabled: false,
+        priceAlert: {
+          isNot: null,
+        },
+      },
+      include: {
+        priceAlert: true,
+      },
+    });
+
+    if (disabledAlerts.length === 0) {
+      await interaction.reply({
+        content: "No disabled alerts found in this channel.",
+        flags: 64,
+      });
+      return;
+    }
+
+    logger.info(`Found ${disabledAlerts.length} disabled alerts to delete`);
+
+    // Delete all disabled alerts
+    let deletedCount = 0;
+    for (const alert of disabledAlerts) {
+      try {
+        // Delete the PriceAlert first if it exists
+        if (alert.priceAlert) {
+          await prisma.priceAlert.delete({
+            where: {
+              alertId: alert.id,
+            },
+          });
+        }
+
+        // Then delete the Alert
+        await prisma.alert.delete({
+          where: {
+            id: alert.id,
+          },
+        });
+
+        deletedCount++;
+      } catch (deleteError) {
+        logger.error(`Error deleting disabled alert ${alert.id}:`, deleteError);
+        // Continue with other alerts even if one fails
+      }
+    }
+
+    logger.info(`Successfully deleted ${deletedCount} disabled alerts`);
+    await interaction.reply({
+      content: `Successfully deleted ${deletedCount} disabled alerts from this channel.`,
+      flags: 64,
+    });
+  } catch (error) {
+    logger.error("Error deleting disabled alerts:", {
+      error,
+      guildId,
+      channelId,
+    });
+
+    let errorMessage = "Sorry, there was an error deleting the disabled alerts.";
+    if (error instanceof Error) {
+      errorMessage += ` Error: ${error.message}`;
+    }
+
+    await interaction.reply({
+      content: errorMessage,
+      flags: 64,
+    });
+  }
+}
+
+async function handleDeleteSpecificAlert(
+  interaction: ChatInputCommandInteraction,
+  alertId: string,
+  guildId: string,
+  channelId: string
+): Promise<void> {
   try {
     logger.info(`Attempting to delete alert ${alertId} from guild ${guildId} channel ${channelId}`);
 

--- a/src/alertCommands/disablePriceAlert.ts
+++ b/src/alertCommands/disablePriceAlert.ts
@@ -8,20 +8,27 @@ import prisma from "../utils/prisma";
 
 export const disablePriceAlertCommand = new SlashCommandBuilder()
   .setName("disable-alert")
-  .setDescription("Disables a price alert by its ID (sets enabled to false).")
+  .setDescription("Disables a price alert by its ID or all enabled alerts.")
   .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
   .addStringOption((option) =>
     option
       .setName("id")
       .setDescription("The ID of the alert to disable.")
-      .setRequired(true)
+      .setRequired(false)
+  )
+  .addBooleanOption((option) =>
+    option
+      .setName("disable-all")
+      .setDescription("Disable all enabled alerts in this channel.")
+      .setRequired(false)
   )
   .toJSON();
 
 export async function handleDisablePriceAlert(
   interaction: ChatInputCommandInteraction
 ): Promise<void> {
-  const alertId = interaction.options.getString("id", true);
+  const alertId = interaction.options.getString("id");
+  const disableAll = interaction.options.getBoolean("disable-all");
   const { guildId, channelId } = interaction;
 
   if (!guildId || !channelId) {
@@ -32,6 +39,103 @@ export async function handleDisablePriceAlert(
     return;
   }
 
+  // Check if at least one option is provided
+  if (!alertId && disableAll === null) {
+    await interaction.reply({
+      content: "Please provide either an alert ID or use the disable-all option.",
+      flags: 64,
+    });
+    return;
+  }
+
+  // Handle disabling all enabled alerts
+  if (disableAll === true) {
+    await handleDisableAllEnabledAlerts(interaction, guildId, channelId);
+    return;
+  }
+
+  // Handle disabling a specific alert by ID
+  if (alertId) {
+    await handleDisableSpecificAlert(interaction, alertId, guildId, channelId);
+    return;
+  }
+}
+
+async function handleDisableAllEnabledAlerts(
+  interaction: ChatInputCommandInteraction,
+  guildId: string,
+  channelId: string
+): Promise<void> {
+  try {
+    logger.info(`Attempting to disable all enabled alerts from guild ${guildId} channel ${channelId}`);
+
+    // Find all enabled alerts in this channel
+    const enabledAlerts = await prisma.alert.findMany({
+      where: {
+        discordServerId: guildId,
+        channelId: channelId,
+        enabled: true,
+        priceAlert: {
+          isNot: null,
+        },
+      },
+    });
+
+    if (enabledAlerts.length === 0) {
+      await interaction.reply({
+        content: "No enabled alerts found in this channel.",
+        flags: 64,
+      });
+      return;
+    }
+
+    logger.info(`Found ${enabledAlerts.length} enabled alerts to disable`);
+
+    // Disable all enabled alerts
+    let disabledCount = 0;
+    for (const alert of enabledAlerts) {
+      try {
+        await prisma.alert.update({
+          where: { id: alert.id },
+          data: { enabled: false },
+        });
+        disabledCount++;
+      } catch (updateError) {
+        logger.error(`Error disabling alert ${alert.id}:`, updateError);
+        // Continue with other alerts even if one fails
+      }
+    }
+
+    logger.info(`Successfully disabled ${disabledCount} alerts`);
+    await interaction.reply({
+      content: `Successfully disabled ${disabledCount} alerts in this channel.`,
+      flags: 64,
+    });
+  } catch (error) {
+    logger.error("Error disabling all enabled alerts:", {
+      error,
+      guildId,
+      channelId,
+    });
+
+    let errorMessage = "Sorry, there was an error disabling the alerts.";
+    if (error instanceof Error) {
+      errorMessage += ` Error: ${error.message}`;
+    }
+
+    await interaction.reply({
+      content: errorMessage,
+      flags: 64,
+    });
+  }
+}
+
+async function handleDisableSpecificAlert(
+  interaction: ChatInputCommandInteraction,
+  alertId: string,
+  guildId: string,
+  channelId: string
+): Promise<void> {
   try {
     logger.info(`Attempting to disable alert ${alertId} from guild ${guildId} channel ${channelId}`);
 

--- a/src/alertCommands/disablePriceAlert.ts
+++ b/src/alertCommands/disablePriceAlert.ts
@@ -39,7 +39,7 @@ export async function handleDisablePriceAlert(
     return;
   }
 
-  // Check if at least one option is provided
+  
   if (!alertId && disableAll === null) {
     await interaction.reply({
       content: "Please provide either an alert ID or use the disable-all option.",
@@ -48,13 +48,13 @@ export async function handleDisablePriceAlert(
     return;
   }
 
-  // Handle disabling all enabled alerts
+  // bulk
   if (disableAll === true) {
     await handleDisableAllEnabledAlerts(interaction, guildId, channelId);
     return;
   }
 
-  // Handle disabling a specific alert by ID
+  // specific
   if (alertId) {
     await handleDisableSpecificAlert(interaction, alertId, guildId, channelId);
     return;
@@ -69,7 +69,7 @@ async function handleDisableAllEnabledAlerts(
   try {
     logger.info(`Attempting to disable all enabled alerts from guild ${guildId} channel ${channelId}`);
 
-    // Find all enabled alerts in this channel
+    
     const enabledAlerts = await prisma.alert.findMany({
       where: {
         discordServerId: guildId,
@@ -91,7 +91,7 @@ async function handleDisableAllEnabledAlerts(
 
     logger.info(`Found ${enabledAlerts.length} enabled alerts to disable`);
 
-    // Disable all enabled alerts
+    
     let disabledCount = 0;
     for (const alert of enabledAlerts) {
       try {
@@ -102,7 +102,7 @@ async function handleDisableAllEnabledAlerts(
         disabledCount++;
       } catch (updateError) {
         logger.error(`Error disabling alert ${alert.id}:`, updateError);
-        // Continue with other alerts even if one fails
+        
       }
     }
 
@@ -139,7 +139,7 @@ async function handleDisableSpecificAlert(
   try {
     logger.info(`Attempting to disable alert ${alertId} from guild ${guildId} channel ${channelId}`);
 
-    // Check if the alert exists and belongs to this server/channel
+    // alert ownership check
     const alert = await prisma.alert.findUnique({
       where: {
         id: alertId,
@@ -161,7 +161,7 @@ async function handleDisableSpecificAlert(
     }
 
     try {
-      // Set enabled to false
+      
       await prisma.alert.update({
         where: { id: alertId },
         data: { enabled: false },

--- a/src/alertCommands/enablePriceAlert.ts
+++ b/src/alertCommands/enablePriceAlert.ts
@@ -39,7 +39,7 @@ export async function handleEnablePriceAlert(
     return;
   }
 
-  // Check if at least one option is provided
+  
   if (!alertId && enableAll === null) {
     await interaction.reply({
       content: 'Please provide either an alert ID or use the enable-all option.',
@@ -48,13 +48,13 @@ export async function handleEnablePriceAlert(
     return;
   }
 
-  // Handle enabling all disabled alerts
+  // bulk
   if (enableAll === true) {
     await handleEnableAllDisabledAlerts(interaction, guildId, channelId);
     return;
   }
 
-  // Handle enabling a specific alert by ID
+  // specific
   if (alertId) {
     await handleEnableSpecificAlert(interaction, alertId, guildId, channelId);
     return;
@@ -69,7 +69,7 @@ async function handleEnableAllDisabledAlerts(
   try {
     logger.info(`Attempting to enable all disabled alerts from guild ${guildId} channel ${channelId}`);
 
-    // Find all disabled alerts in this channel
+    
     const disabledAlerts = await prisma.alert.findMany({
       where: {
         discordServerId: guildId,
@@ -91,7 +91,7 @@ async function handleEnableAllDisabledAlerts(
 
     logger.info(`Found ${disabledAlerts.length} disabled alerts to enable`);
 
-    // Enable all disabled alerts
+    
     let enabledCount = 0;
     for (const alert of disabledAlerts) {
       try {
@@ -105,7 +105,7 @@ async function handleEnableAllDisabledAlerts(
         enabledCount++;
       } catch (updateError) {
         logger.error(`Error enabling alert ${alert.id}:`, updateError);
-        // Continue with other alerts even if one fails
+        
       }
     }
 
@@ -144,7 +144,7 @@ async function handleEnableSpecificAlert(
       `Attempting to enable alert ${alertId} from guild ${guildId} channel ${channelId}`
     );
 
-    // Check if the alert exists and belongs to this server/channel
+    // alert ownership check
     const alert = await prisma.alert
       .findUnique({
         where: {
@@ -177,7 +177,7 @@ async function handleEnableSpecificAlert(
     }
 
     try {
-      // Set enabled to true and reset lastTriggered to allow immediate triggering
+      
       await prisma.alert.update({
         where: { id: alertId },
         data: {

--- a/src/alertCommands/enablePriceAlert.ts
+++ b/src/alertCommands/enablePriceAlert.ts
@@ -8,20 +8,27 @@ import prisma from '../utils/prisma';
 
 export const enablePriceAlertCommand = new SlashCommandBuilder()
   .setName('enable-alert')
-  .setDescription('Enables a price alert by its ID (sets enabled to true).')
+  .setDescription('Enables a price alert by its ID or all disabled alerts.')
   .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
   .addStringOption(option =>
     option
       .setName('id')
       .setDescription('The ID of the alert to enable.')
-      .setRequired(true)
+      .setRequired(false)
+  )
+  .addBooleanOption(option =>
+    option
+      .setName('enable-all')
+      .setDescription('Enable all disabled alerts in this channel.')
+      .setRequired(false)
   )
   .toJSON();
 
 export async function handleEnablePriceAlert(
   interaction: ChatInputCommandInteraction
 ): Promise<void> {
-  const alertId = interaction.options.getString('id', true);
+  const alertId = interaction.options.getString('id');
+  const enableAll = interaction.options.getBoolean('enable-all');
   const { guildId, channelId } = interaction;
 
   if (!guildId || !channelId) {
@@ -32,6 +39,106 @@ export async function handleEnablePriceAlert(
     return;
   }
 
+  // Check if at least one option is provided
+  if (!alertId && enableAll === null) {
+    await interaction.reply({
+      content: 'Please provide either an alert ID or use the enable-all option.',
+      flags: 64,
+    });
+    return;
+  }
+
+  // Handle enabling all disabled alerts
+  if (enableAll === true) {
+    await handleEnableAllDisabledAlerts(interaction, guildId, channelId);
+    return;
+  }
+
+  // Handle enabling a specific alert by ID
+  if (alertId) {
+    await handleEnableSpecificAlert(interaction, alertId, guildId, channelId);
+    return;
+  }
+}
+
+async function handleEnableAllDisabledAlerts(
+  interaction: ChatInputCommandInteraction,
+  guildId: string,
+  channelId: string
+): Promise<void> {
+  try {
+    logger.info(`Attempting to enable all disabled alerts from guild ${guildId} channel ${channelId}`);
+
+    // Find all disabled alerts in this channel
+    const disabledAlerts = await prisma.alert.findMany({
+      where: {
+        discordServerId: guildId,
+        channelId: channelId,
+        enabled: false,
+        priceAlert: {
+          isNot: null,
+        },
+      },
+    });
+
+    if (disabledAlerts.length === 0) {
+      await interaction.reply({
+        content: 'No disabled alerts found in this channel.',
+        flags: 64,
+      });
+      return;
+    }
+
+    logger.info(`Found ${disabledAlerts.length} disabled alerts to enable`);
+
+    // Enable all disabled alerts
+    let enabledCount = 0;
+    for (const alert of disabledAlerts) {
+      try {
+        await prisma.alert.update({
+          where: { id: alert.id },
+          data: {
+            enabled: true,
+            lastTriggered: null,
+          },
+        });
+        enabledCount++;
+      } catch (updateError) {
+        logger.error(`Error enabling alert ${alert.id}:`, updateError);
+        // Continue with other alerts even if one fails
+      }
+    }
+
+    logger.info(`Successfully enabled ${enabledCount} alerts`);
+    await interaction.reply({
+      content: `Successfully enabled ${enabledCount} alerts in this channel.`,
+      flags: 64,
+    });
+  } catch (error) {
+    logger.error('Error enabling all disabled alerts:', {
+      error,
+      guildId,
+      channelId,
+    });
+
+    let errorMessage = 'Sorry, there was an error enabling the alerts.';
+    if (error instanceof Error) {
+      errorMessage += ` Error: ${error.message}`;
+    }
+
+    await interaction.reply({
+      content: errorMessage,
+      flags: 64,
+    });
+  }
+}
+
+async function handleEnableSpecificAlert(
+  interaction: ChatInputCommandInteraction,
+  alertId: string,
+  guildId: string,
+  channelId: string
+): Promise<void> {
   try {
     logger.info(
       `Attempting to enable alert ${alertId} from guild ${guildId} channel ${channelId}`


### PR DESCRIPTION



## Description
Enhanced price alert management with bulk operations for enabling and disabling alerts.

### Changes
- **Enable Alert Command**: Added `enable-all:true` option to enable all disabled alerts in a channel
- **Disable Alert Command**: Added `disable-all:true` option to disable all enabled alerts in a channel
- **Smart Validation**: Commands now require either an alert ID or bulk operation flag
- **Bulk Processing**: Efficiently manage multiple alerts with single commands
- **Cooldown Reset**: Re-enabling alerts resets trigger cooldown for immediate activation

### Usage Examples
```
/enable-alert enable-all:true     # Enable all disabled alerts
/disable-alert disable-all:true   # Disable all enabled alerts
/enable-alert id:123              # Enable specific alert (existing)
/disable-alert id:123             # Disable specific alert (existing)
```

### Benefits
- Streamlined alert management for server administrators
- Channel-specific bulk operations
- Maintains existing single-alert functionality
- Comprehensive error handling and logging