### PR TITLE
feat: add check for already disabled alerts in disablePriceAlert command

### DIFF
--- a/src/alertCommands/disablePriceAlert.ts
+++ b/src/alertCommands/disablePriceAlert.ts
@@ -160,6 +160,15 @@ async function handleDisableSpecificAlert(
       return;
     }
 
+    if (!alert.enabled) {
+      logger.info(`Alert ${alertId} is already disabled.`);
+      await interaction.reply({
+        content: `Alert with ID: \`${alertId}\` is already disabled.`,
+        flags: 64,
+      });
+      return;
+    }
+
     try {
       
       await prisma.alert.update({


### PR DESCRIPTION
### Description
This PR adds validation to prevent unnecessary operations when attempting to disable alerts that are already disabled, improving user experience and preventing redundant database operations.

### Changes Made
- Added validation in [handleDisableSpecificAlert]
- Added a check to verify if the alert is already disabled before attempting to disable it
- Improved user feedback: Users now receive a clear message when trying to disable an already-disabled alert
- Enhanced logging: Added logging when skipping already-disabled alerts for better debugging