### PR TITLE
fix: resolve server isolation vulnerability in alert management commands

### DIFF
--- a/src/alertCommands/deletePriceAlert.ts
+++ b/src/alertCommands/deletePriceAlert.ts
@@ -144,8 +144,7 @@ async function handleDeleteSpecificAlert(
   try {
     logger.info(`Attempting to delete alert ${alertId} from guild ${guildId} channel ${channelId}`);
 
-    // alert ownership check
-    const alert = await prisma.alert.findUnique({
+    const alert = await prisma.alert.findFirst({
       where: {
         id: alertId,
         discordServerId: guildId,

--- a/src/alertCommands/disablePriceAlert.ts
+++ b/src/alertCommands/disablePriceAlert.ts
@@ -160,6 +160,15 @@ async function handleDisableSpecificAlert(
       return;
     }
 
+    if (!alert.enabled) {
+      logger.info(`Alert ${alertId} is already disabled.`);
+      await interaction.reply({
+        content: `Alert with ID: \`${alertId}\` is already disabled.`,
+        flags: 64,
+      });
+      return;
+    }
+
     try {
       
       await prisma.alert.update({

--- a/src/alertCommands/disablePriceAlert.ts
+++ b/src/alertCommands/disablePriceAlert.ts
@@ -139,8 +139,7 @@ async function handleDisableSpecificAlert(
   try {
     logger.info(`Attempting to disable alert ${alertId} from guild ${guildId} channel ${channelId}`);
 
-    // alert ownership check
-    const alert = await prisma.alert.findUnique({
+    const alert = await prisma.alert.findFirst({
       where: {
         id: alertId,
         discordServerId: guildId,

--- a/src/alertCommands/editPriceAlert.ts
+++ b/src/alertCommands/editPriceAlert.ts
@@ -60,7 +60,7 @@ export async function handleEditPriceAlert(
   }
 
   try {
-    const alert = await prisma.alert.findUnique({
+    const alert = await prisma.alert.findFirst({
       where: {
         id: alertId,
         discordServerId: guildId,

--- a/src/alertCommands/enablePriceAlert.ts
+++ b/src/alertCommands/enablePriceAlert.ts
@@ -144,9 +144,8 @@ async function handleEnableSpecificAlert(
       `Attempting to enable alert ${alertId} from guild ${guildId} channel ${channelId}`
     );
 
-    // alert ownership check
     const alert = await prisma.alert
-      .findUnique({
+      .findFirst({
         where: {
           id: alertId,
           discordServerId: guildId,


### PR DESCRIPTION
## Security Fix

Fixes a critical vulnerability where users could access alerts from other Discord servers by knowing alert IDs.
- Fixes : #48 

### Issue
- `findUnique()` with composite where clauses only uses the first unique field (id)
- Guild ID and channel ID checks were being ignored
- Users could potentially manipulate alerts across different servers

### Solution
- Replace `findUnique()` with `findFirst()` in all alert ownership checks
- Ensures proper enforcement of guild and channel isolation

### Files Changed
- `deletePriceAlert.ts`
- `editPriceAlert.ts` 
- `disablePriceAlert.ts`
- `enablePriceAlert.ts`

### Testing
- ✅ All files compile without errors
- ✅ No breaking changes for legitimate users
- ✅ Server isolation now