### PR TITLE
feat: add edit volume alert command and handler

### DIFF
--- a/src/alertCommands/editVolumeAlert.ts
+++ b/src/alertCommands/editVolumeAlert.ts
@@ -1,0 +1,71 @@
+import {
+  ChatInputCommandInteraction,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+} from 'discord.js';
+import { AlertDirection } from '../generated/prisma/client';
+import logger from '../utils/logger';
+import { editVolumeAlert } from '../lib/alertcommands';
+
+export const editVolumeAlertCommand = new SlashCommandBuilder()
+  .setName('edit-volume-alert')
+  .setDescription('Edits an existing volume alert.')
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
+  .addStringOption(option =>
+    option
+      .setName('id')
+      .setDescription('The ID of the volume alert to edit.')
+      .setRequired(true)
+  )
+  .addStringOption(option =>
+    option
+      .setName('direction')
+      .setDescription('The new volume direction to alert on.')
+      .setRequired(false)
+      .addChoices({ name: 'Up', value: 'up' }, { name: 'Down', value: 'down' })
+  )
+  .addNumberOption(option =>
+    option
+      .setName('value')
+      .setDescription('The new volume value to alert at.')
+      .setRequired(false)
+  )
+  .toJSON();
+
+export async function handleEditVolumeAlert(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  const alertId = interaction.options.getString('id', true);
+  const newDirection = interaction.options.getString('direction') as AlertDirection | null;
+  const newValue = interaction.options.getNumber('value');
+  const { guildId, channelId } = interaction;
+
+  if (!guildId || !channelId) {
+    await interaction.reply({
+      content: 'This command can only be used in a server channel.',
+      flags: 64,
+    });
+    return;
+  }
+
+  try {
+    const result = await editVolumeAlert({
+      alertId,
+      newDirection: newDirection || undefined,
+      newValue: newValue || undefined,
+      guildId,
+      channelId,
+    });
+
+    await interaction.reply({
+      content: result.message,
+      flags: 64,
+    });
+  } catch (error) {
+    logger.error('Error in handleEditVolumeAlert:', error);
+    await interaction.reply({
+      content: 'Sorry, there was an unexpected error. Please try again later.',
+      flags: 64,
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,10 @@ import {
   handleEditPriceAlert,
 } from './alertCommands/editPriceAlert';
 import {
+  editVolumeAlertCommand,
+  handleEditVolumeAlert,
+} from './alertCommands/editVolumeAlert';
+import {
   deletePriceAlertCommand,
   handleDeletePriceAlert,
 } from './alertCommands/deletePriceAlert';
@@ -131,6 +135,7 @@ const commandsData: ApplicationCommandDataResolvable[] = [
   createVolumeAlertCommand,
   listAlertsCommand,
   editPriceAlertCommand,
+  editVolumeAlertCommand,
   deletePriceAlertCommand,
   disablePriceAlertCommand,
   enablePriceAlertCommand,
@@ -274,6 +279,8 @@ async function handleInteractionCommands(
     await handleListAlerts(interaction);
   } else if (commandName === 'edit-price-alert') {
     await handleEditPriceAlert(interaction);
+  } else if (commandName === 'edit-volume-alert') {
+    await handleEditVolumeAlert(interaction);
   } else if (commandName === 'delete-alert') {
     await handleDeletePriceAlert(interaction);
   } else if (commandName === 'disable-alert') {

--- a/src/lib/alertcommands/editVolumeAlert.ts
+++ b/src/lib/alertcommands/editVolumeAlert.ts
@@ -1,0 +1,72 @@
+import logger from '../../utils/logger';
+import prisma from '../../utils/prisma';
+import { AlertDirection } from '../../generated/prisma/client';
+
+export interface EditVolumeAlertParams {
+  alertId: string;
+  newDirection?: AlertDirection;
+  newValue?: number;
+  guildId: string;
+  channelId: string;
+}
+
+export interface EditVolumeAlertResult {
+  success: boolean;
+  message: string;
+}
+
+export async function editVolumeAlert(
+  params: EditVolumeAlertParams
+): Promise<EditVolumeAlertResult> {
+  const { alertId, newDirection, newValue, guildId, channelId } = params;
+
+  if (!alertId) {
+    return {
+      success: false,
+      message: 'Alert ID is required.',
+    };
+  }
+
+  try {
+    const alert = await prisma.alert.findFirst({
+      where: {
+        id: alertId,
+        discordServerId: guildId,
+        channelId: channelId,
+        volumeAlert: {
+          isNot: null,
+        },
+      },
+      include: {
+        volumeAlert: true,
+      },
+    });
+
+    if (!alert || !alert.volumeAlert) {
+      return {
+        success: false,
+        message: 'Volume alert not found for the given ID in this channel.',
+      };
+    }
+
+    const updated = await prisma.volumeAlert.update({
+      where: { id: alert.volumeAlert.id },
+      data: {
+        direction: newDirection || alert.volumeAlert.direction,
+        value: newValue !== undefined ? newValue : alert.volumeAlert.value,
+      },
+    });
+
+    logger.info(`Volume alert ${alertId} updated:`, updated);
+    return {
+      success: true,
+      message: 'Volume alert updated successfully.',
+    };
+  } catch (error) {
+    logger.error('Error editing volume alert:', error);
+    return {
+      success: false,
+      message: 'Failed to update volume alert. Please try again later.',
+    };
+  }
+}

--- a/src/lib/alertcommands/index.ts
+++ b/src/lib/alertcommands/index.ts
@@ -6,4 +6,5 @@ export * from './disableAlert';
 export * from './editPriceAlert';
 export * from './alertStats';
 export * from './createVolumeAlert';
-export * from './alertStats';
+
+export * from './editVolumeAlert';


### PR DESCRIPTION
This PR introduces support for editing volume alerts via Discord commands.

Key changes:
- Added `editVolumeAlertCommand` and `handleEditVolumeAlert` in `src/alertCommands/editVolumeAlert.ts` to allow users to edit existing volume alerts.
- Implemented the `editVolumeAlert` function in `src/lib/alertcommands/editVolumeAlert.ts` for updating volume alert parameters in the database.
- Registered the new command and handler in `src/index.ts` so it is available to Discord users.
- Exported the new function from `src/lib/alertcommands/index.ts` for consistency.
- Ensured the command supports editing direction and value for volume alerts, with proper error handling and user feedback.

This enhancement allows users to manage and update their volume alerts directly from Discord, improving alert flexibility