### PR TITLE
feat: Enable CLI export for alerts and refine module exports

### DIFF
--- a/src/docs/usage.md
+++ b/src/docs/usage.md
@@ -50,6 +50,28 @@ To start the Tokenator bot and connect it to Discord:
 
 Once the bot is running and invited to your Discord server (guild), you can interact with it using Discord slash commands. Commands are not invoked by passing arguments to `ts-node src/index.ts` directly after initial setup.
 
+## CLI Usage
+
+Beyond the Discord bot, Tokenator also provides command-line utilities for specific tasks.
+
+### Exporting Alerts
+
+You can export all alerts for a specific Discord server and channel directly from the command line as a JSON file. This is useful for backup or migration purposes.
+
+```bash
+npm start -- --export-alerts <DISCORD_SERVER_ID> <DISCORD_CHANNEL_ID>
+# Or, for development:
+ts-node src/index.ts --export-alerts <DISCORD_SERVER_ID> <DISCORD_CHANNEL_ID>
+```
+
+*   `<DISCORD_SERVER_ID>`: The ID of the Discord server (guild) where the alerts are configured.
+*   `<DISCORD_CHANNEL_ID>`: The ID of the specific channel within that server where the alerts are configured.
+
+The command will output a JSON string to `stdout` containing all price and volume alerts for the specified server and channel.
+
+**Note:** This command bypasses the Discord bot interface and interacts directly with the database. Ensure you have appropriate permissions and the `DATABASE_URL` environment variable is correctly set.
+
+
 **Note:** The multi-line or colon-separated examples shown below are simplified documentation representations for readability. Users should invoke the slash command in Discord and then supply parameters via Discord's UI modal, not by typing colon-separated inline parameters.
 
 ### Example Alert Commands

--- a/src/docs/usage.md
+++ b/src/docs/usage.md
@@ -56,18 +56,18 @@ Beyond the Discord bot, Tokenator also provides command-line utilities for speci
 
 ### Exporting Alerts
 
-You can export all alerts for a specific Discord server and channel directly from the command line as a JSON file. This is useful for backup or migration purposes.
+You can export all alerts for a specific Discord server and channel directly from the command line as JSON to `stdout`. This is useful for backup or migration purposes.
 
 ```bash
-npm start -- --export-alerts <DISCORD_SERVER_ID> <DISCORD_CHANNEL_ID>
+npm start -- --export-alerts <DISCORD_SERVER_ID> <DISCORD_CHANNEL_ID> > alerts.json
 # Or, for development:
-ts-node src/index.ts --export-alerts <DISCORD_SERVER_ID> <DISCORD_CHANNEL_ID>
+ts-node src/index.ts --export-alerts <DISCORD_SERVER_ID> <DISCORD_CHANNEL_ID> > alerts.json
 ```
 
 *   `<DISCORD_SERVER_ID>`: The ID of the Discord server (guild) where the alerts are configured.
 *   `<DISCORD_CHANNEL_ID>`: The ID of the specific channel within that server where the alerts are configured.
 
-The command will output a JSON string to `stdout` containing all price and volume alerts for the specified server and channel.
+The command will output a JSON string to `stdout` containing all price and volume alerts for the specified server and channel. This output can be redirected to a file, as shown in the examples.
 
 **Note:** This command bypasses the Discord bot interface and interacts directly with the database. Ensure you have appropriate permissions and the `DATABASE_URL` environment variable is correctly set.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ import {
   handleImportAlerts,
 } from './alertCommands/importAlerts';
 import { resolveTokenAlias } from './utils/constants';
-import { exportAlerts } from './lib/alertCommands/exportAlerts';
+import { exportAlerts } from './lib/alertcommands/exportAlerts';
 
 const token: string = config.DISCORD_TOKEN;
 
@@ -502,9 +502,11 @@ if (require.main === module) {
 
   if (cliArgs.exportAlerts) {
     logger.info('Running alert export command...');
+    const discordServerId = cliArgs.exportAlerts.discordServerId;
+    const channelId = cliArgs.exportAlerts.channelId;
     (async () => {
       try {
-        const exitCode = await cliExportAlerts(cliArgs.exportAlerts.discordServerId, cliArgs.exportAlerts.channelId);
+        const exitCode = await cliExportAlerts(discordServerId, channelId);
         process.exit(exitCode);
       } catch (error) {
         let msg: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -410,11 +410,6 @@ async function main(): Promise<void> {
 
 interface CliArgs {
   help: boolean;
-  // Add other CLI arguments here as needed
-}
-
-interface CliArgs {
-  help: boolean;
   exportAlerts: {
     discordServerId: string;
     channelId: string;
@@ -463,7 +458,7 @@ Usage:
 
 Options:
   -h, --help                          Display this help message.
-  --export-alerts <SERVER_ID> <CHANNEL_ID>  Export all alerts for a specific Discord server and channel as JSON.
+  --export-alerts <DISCORD_SERVER_ID> <DISCORD_CHANNEL_ID>  Export all alerts for a specific Discord server and channel as JSON.
 
 Description:
   Tokenator is a feature-rich Discord bot for token price alerts and information.
@@ -474,15 +469,17 @@ Description:
   `);
 }
 
-async function cliExportAlerts(discordServerId: string, channelId: string): Promise<void> {
+async function cliExportAlerts(discordServerId: string, channelId: string): Promise<number> {
   try {
     const alertsJson = await exportAlerts(prisma, discordServerId, channelId);
     console.log(alertsJson);
     logger.info(`Alerts exported for server ${discordServerId} and channel ${channelId} via CLI.`);
-    process.exit(0);
+    return 0;
   } catch (error) {
     logger.error(`Failed to export alerts via CLI for server ${discordServerId}, channel ${channelId}: ${error.message}`);
-    process.exit(1);
+    return 1;
+  } finally {
+    await prisma.$disconnect();
   }
 }
 
@@ -499,9 +496,8 @@ if (require.main === module) {
 
   if (cliArgs.exportAlerts) {
     logger.info('Running alert export command...');
-    // Ensure prisma and exportAlerts are imported correctly for CLI usage
-    // This assumes `exportAlerts` is available globally or imported here
-    cliExportAlerts(cliArgs.exportAlerts.discordServerId, cliArgs.exportAlerts.channelId);
+    const exitCode = await cliExportAlerts(cliArgs.exportAlerts.discordServerId, cliArgs.exportAlerts.channelId);
+    process.exit(exitCode);
   } else {
     main();
   }


### PR DESCRIPTION
Overview: This change introduces a new CLI entry point to simplify running alert export commands and refines module exports for better organization.

## Changes

*   Added a CLI entry in `src/index.ts` to enable direct execution of alert export functionality.
*   Cleaned up and organized exports within `src/index.ts` to improve module clarity and maintainability.
*   Updated `src/alertCommands/exportAlerts.ts` to support the new CLI integration.
*   Included an example in `docs/USAGE.md` demonstrating how to use the new CLI export command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to export all alerts from a specified Discord server and channel as JSON to stdout, with validation and clear exit codes.

* **Documentation**
  * Added CLI usage docs detailing invocation methods, required parameters (server/channel IDs), environment requirements, permission considerations, and note about bypassing the bot UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->